### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ __version__ = "0.0.1"
 with open("README.md") as readme_file:
     long_description = readme_file.read()
 
-requires = ["fastavro>=0.22.3", "requests-async==0.4.1" "aiofiles==0.4.0"]
+requires = ["fastavro>=0.22.3", "requests-async==0.4.1", "aiofiles==0.4.0"]
 
 setup(
     name="async-python-schema-registry-client",


### PR DESCRIPTION
```
$ pip install -U async-python-schema-registry-client
ERROR: Could not find a version that satisfies the requirement requests-async==0.4.1aiofiles==0.4.0 (from async-python-schema-registry-client)
```

Add missing coma.